### PR TITLE
Removed init since all dependecies are vendored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,17 +62,6 @@ clean: ## Cleanup
 	@echo -e "$(OK_COLOR)[$(APP)] Cleanup$(NO_COLOR)"
 	@rm -fr $(EXE) $(APP) $(APP)-*.tar.gz
 
-.PHONY: init
-init: ## Install requirements
-	@echo -e "$(OK_COLOR)[$(APP)] Install requirements$(NO_COLOR)"
-	@go get -u github.com/golang/glog
-	@go get -u github.com/kardianos/govendor
-	@go get -u github.com/Masterminds/rmvcsdir
-	@go get -u github.com/golang/lint/golint
-	@go get -u github.com/kisielk/errcheck
-	@go get -u golang.org/x/tools/cmd/oracle
-	@go get -u github.com/mitchellh/gox
-
 .PHONY: deps
 deps: ## Install dependencies
 	@echo -e "$(OK_COLOR)[$(APP)] Update dependencies$(NO_COLOR)"

--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ Launch the Prometheus exporter :
 
 ## Development
 
-* Initialize environment
-
-        $ make init
-
 * Build tool :
 
         $ make build


### PR DESCRIPTION
Since all dependencies are vendored the init method of the make file is not needed and only confuses people following the README.

Addresses https://github.com/nlamirault/pihole_exporter/issues/2