### PR TITLE
Added dockerfile and updated readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine AS build
+RUN apk add --no-cache alpine-sdk bash
+WORKDIR /go/src/github.com/nlamirault/pihole_exporter
+COPY . .
+RUN go build -o /app/pihole_exporter pihole_exporter.go && chmod +x /app/pihole_exporter
+
+FROM alpine:latest
+COPY --from=build /app/pihole_exporter /app/pihole_exporter
+WORKDIR /app
+ENTRYPOINT ["./pihole_exporter"]
+CMD ["-h"]
+EXPOSE 9311

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Launch the Prometheus exporter :
         $ docker run -d --name=grafana -p 3000:3000 grafana/grafana
 
 
+## Docker Deployment
+
+* Build Image:
+
+		$ docker build -t pihole-exporter .
+
+* Start Container
+		
+		$ docker run -d -p 9311:9311 pihole-exporter -pihole http://192.168.1.5
+
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Added dockerfile to build a small alpine image at 12mb.

```
$ docker build -t pihole-exporter .
$ docker run -d -p 9311:9311 pihole-exporter -pihole http://192.168.1.5
```

If no arguments are passed it will default to running the help output.